### PR TITLE
Removed allowsBackup from manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,8 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.esafirm.rxdownloader">
-
-    <application android:allowBackup="true"
-                 android:label="@string/app_name">
-    </application>
-
-</manifest>
+<manifest package="com.esafirm.rxdownloader" />


### PR DESCRIPTION
When importing the library, the manifest flag `allowBackup` was clashing with our manifest and there didn't seem  to be a good reason to keep it in the library.