### PR TITLE
Release the DownloadManager query cursor when finished

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.esafirm.rxdownloadmanager"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 10 21:45:32 WIB 2015
+#Tue Apr 18 15:43:09 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,6 +21,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     /* Rx */
-    compile 'io.reactivex:rxjava:1.2.1'
-    compile 'com.artemzin.rxjava:proguard-rules:1.2.1.0'
+    compile 'io.reactivex:rxjava:1.2.9'
+    compile 'com.artemzin.rxjava:proguard-rules:1.2.9.0'
 }

--- a/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
+++ b/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
@@ -85,6 +85,7 @@ public class RxDownloader {
             Cursor cursor = mDownloadManager.query(query);
 
             if (!cursor.moveToFirst()) {
+                cursor.close();
                 mDownloadManager.remove(id);
                 publishSubject.onError(new IllegalStateException("Cursor empty, this shouldn't happened"));
                 mSubjectMap.remove(id);
@@ -93,6 +94,7 @@ public class RxDownloader {
 
             int statusIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS);
             if (DownloadManager.STATUS_SUCCESSFUL != cursor.getInt(statusIndex)) {
+                cursor.close();
                 mDownloadManager.remove(id);
                 publishSubject.onError(new IllegalStateException("Download Failed"));
                 mSubjectMap.remove(id);
@@ -101,6 +103,7 @@ public class RxDownloader {
 
             int uriIndex = cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI);
             String downloadedPackageUriString = cursor.getString(uriIndex);
+            cursor.close();
 
             publishSubject.onNext(downloadedPackageUriString);
             publishSubject.onCompleted();


### PR DESCRIPTION
This fixes the following exception which occurs when running in strict mode

> E/StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
> java.lang.Throwable: Explicit termination method 'close' not called