### PR TITLE
Add progress observable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '26.0.2'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.esafirm.rxdownloadmanager"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,19 +20,19 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    compile project(':library')
-    compile 'com.android.support:appcompat-v7:27.0.0'
+    implementation project(':library')
+    implementation 'com.android.support:appcompat-v7:27.0.0'
 
-    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
 
     /* Image Loader */
-    compile 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
 
     /* --------------------------------------------------- */
     /* > Test */
     /* --------------------------------------------------- */
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,5 +34,6 @@ dependencies {
     /* > Test */
     /* --------------------------------------------------- */
 
+    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,9 @@
-<manifest
-    package="com.esafirm.rxdownloadmanager"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.esafirm.rxdownloadmanager">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"
@@ -11,17 +11,20 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-
-        <activity
-            android:name="com.esafirm.rxdownloadmanager.SampleAct"
+        <activity android:name=".MainActivity"
             android:label="RxDownloader Sample App">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
+        <activity
+            android:name=".SampleActivity"
+            android:label="Simple Download">
+        </activity>
+        <activity
+            android:name=".SampleProgressActivity"
+            android:label="Download With Progress"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/esafirm/rxdownloadmanager/MainActivity.java
+++ b/app/src/main/java/com/esafirm/rxdownloadmanager/MainActivity.java
@@ -1,0 +1,32 @@
+package com.esafirm.rxdownloadmanager;
+
+import android.content.Intent;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.view.View;
+
+public class MainActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.main);
+
+        findViewById(R.id.button_simple).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        startActivity(new Intent(MainActivity.this, SampleActivity.class));
+                    }
+                }
+        );
+        findViewById(R.id.button_progress).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        startActivity(new Intent(MainActivity.this, SampleProgressActivity.class));
+                    }
+                }
+        );
+    }
+}

--- a/app/src/main/java/com/esafirm/rxdownloadmanager/SampleAct.java
+++ b/app/src/main/java/com/esafirm/rxdownloadmanager/SampleAct.java
@@ -3,31 +3,21 @@ package com.esafirm.rxdownloadmanager;
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.PermissionChecker;
-import android.util.Log;
 import android.util.Pair;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.bumptech.glide.Glide;
 import com.esafirm.rxdownloader.RxDownloader;
-
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
 import java.util.Locale;
 
 import io.reactivex.Observer;
-import io.reactivex.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
@@ -37,7 +27,6 @@ import io.reactivex.schedulers.Schedulers;
  */
 public class SampleAct extends FragmentActivity {
 
-    private static final String TAG = SampleAct.class.getSimpleName();
     private TextView tv_progress;
 
     @Override
@@ -52,53 +41,37 @@ public class SampleAct extends FragmentActivity {
         findViewById(R.id.btn_download).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Toast.makeText(getApplication(), "Look at the notification!", Toast.LENGTH_SHORT).show();
-
                 RxDownloader rxDownloader = new RxDownloader(SampleAct.this);
                 rxDownloader.downloadWithProgress(
-                        /*"https://github.com/esafirm/RxDownloader/archive/master.zip"*/
                         "http://ipv4.download.thinkbroadband.com/20MB.zip",
-                        "rxdownloader-master.zip",
+                        "20MB.zip",
                         "application/zip",
                         true)
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(new Subscriber<Pair<Integer, String>>() {
+                        .subscribe(new Observer<Pair<Integer,String>>() {
 
                             @Override
-                            public void onSubscribe(Subscription s) {
-                                Log.d(TAG, "onSubscribe: ");
+                            public void onSubscribe(Disposable d) {
+                                // do nothing
                             }
 
                             @Override
                             public void onNext(Pair<Integer, String> pair) {
-                                Log.d(TAG, "onNext() called with: pair = [" + pair + "]");
-                                Log.d("Sample", "Is in main thread? " + (Looper.getMainLooper() == Looper.myLooper()));
-                                tv_progress.setText(String.format(Locale.US, "%d", pair.first));
+                                tv_progress.setText(String.format(Locale.US, "%d%%", pair.first));
                                 if (pair.second != null) {
-                                    Toast.makeText(getApplication(), "Downloaded to " + pair, Toast.LENGTH_SHORT).show();
-//
-//                                    ImageView imageView = new ImageView(SampleAct.this);
-//                                    imageView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-//                                            ViewGroup.LayoutParams.WRAP_CONTENT));
-//                                    ((ViewGroup) findViewById(R.id.container)).addView(imageView);
-//
-//                                    Glide.with(SampleAct.this)
-//                                            .load(R.mipmap.ic_launcher)
-//                                            .into(imageView);
+                                    Toast.makeText(getApplication(), "Downloaded to " + pair.second, Toast.LENGTH_SHORT).show();
                                 }
                             }
 
                             @Override
                             public void onError(Throwable e) {
-                                Log.d(TAG, "onError() called with: e = [" + e + "]");
                                 Toast.makeText(getApplication(), "Error!", Toast.LENGTH_SHORT).show();
                             }
 
                             @Override
                             public void onComplete() {
-                                Log.d(TAG, "onComplete() called");
-                                Log.d("Sample", "Is in main thread? " + (Looper.getMainLooper() == Looper.myLooper()));
+                                // do nothing
                             }
                         });
             }

--- a/app/src/main/java/com/esafirm/rxdownloadmanager/SampleAct.java
+++ b/app/src/main/java/com/esafirm/rxdownloadmanager/SampleAct.java
@@ -8,11 +8,11 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.PermissionChecker;
-import android.util.Pair;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.esafirm.rxdownloader.DownloadState;
 import com.esafirm.rxdownloader.RxDownloader;
 
 import java.util.Locale;
@@ -49,7 +49,7 @@ public class SampleAct extends FragmentActivity {
                         true)
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(new Observer<Pair<Integer,String>>() {
+                        .subscribe(new Observer<DownloadState>() {
 
                             @Override
                             public void onSubscribe(Disposable d) {
@@ -57,10 +57,10 @@ public class SampleAct extends FragmentActivity {
                             }
 
                             @Override
-                            public void onNext(Pair<Integer, String> pair) {
-                                tv_progress.setText(String.format(Locale.US, "%d%%", pair.first));
-                                if (pair.second != null) {
-                                    Toast.makeText(getApplication(), "Downloaded to " + pair.second, Toast.LENGTH_SHORT).show();
+                            public void onNext(DownloadState state) {
+                                tv_progress.setText(String.format(Locale.US, "%d%%", state.progress));
+                                if (state.path != null) {
+                                    Toast.makeText(getApplication(), "Downloaded to " + state.path, Toast.LENGTH_SHORT).show();
                                 }
                             }
 

--- a/app/src/main/java/com/esafirm/rxdownloadmanager/SampleAct.java
+++ b/app/src/main/java/com/esafirm/rxdownloadmanager/SampleAct.java
@@ -10,23 +10,35 @@ import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.PermissionChecker;
 import android.util.Log;
+import android.util.Pair;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.esafirm.rxdownloader.RxDownloader;
 
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.Locale;
+
 import io.reactivex.Observer;
+import io.reactivex.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 
 /**
  * Created by esa on 11/11/15, with awesomeness
  */
 public class SampleAct extends FragmentActivity {
+
+    private static final String TAG = SampleAct.class.getSimpleName();
+    private TextView tv_progress;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -36,45 +48,56 @@ public class SampleAct extends FragmentActivity {
     }
 
     private void startSample() {
+        tv_progress = findViewById(R.id.progress);
         findViewById(R.id.btn_download).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 Toast.makeText(getApplication(), "Look at the notification!", Toast.LENGTH_SHORT).show();
 
                 RxDownloader rxDownloader = new RxDownloader(SampleAct.this);
-                rxDownloader.download(
-                        "https://upload.wikimedia.org/wikipedia/en/e/ed/Nyan_cat_250px_frame.PNG",
-                        "nyancat photo",
-                        "image/jpg",
+                rxDownloader.downloadWithProgress(
+                        /*"https://github.com/esafirm/RxDownloader/archive/master.zip"*/
+                        "http://ipv4.download.thinkbroadband.com/20MB.zip",
+                        "rxdownloader-master.zip",
+                        "application/zip",
                         true)
-                        .subscribeOn(AndroidSchedulers.mainThread())
-                        .subscribe(new Observer<String>() {
-                            @Override
-                            public void onSubscribe(Disposable d) {
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(new Subscriber<Pair<Integer, String>>() {
 
+                            @Override
+                            public void onSubscribe(Subscription s) {
+                                Log.d(TAG, "onSubscribe: ");
                             }
 
                             @Override
-                            public void onNext(String filePath) {
-                                Toast.makeText(getApplication(), "Downloaded to " + filePath, Toast.LENGTH_SHORT).show();
-
-                                ImageView imageView = new ImageView(SampleAct.this);
-                                imageView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                                        ViewGroup.LayoutParams.WRAP_CONTENT));
-                                ((ViewGroup) findViewById(R.id.container)).addView(imageView);
-
-                                Glide.with(SampleAct.this)
-                                        .load(filePath)
-                                        .into(imageView);
+                            public void onNext(Pair<Integer, String> pair) {
+                                Log.d(TAG, "onNext() called with: pair = [" + pair + "]");
+                                Log.d("Sample", "Is in main thread? " + (Looper.getMainLooper() == Looper.myLooper()));
+                                tv_progress.setText(String.format(Locale.US, "%d", pair.first));
+                                if (pair.second != null) {
+                                    Toast.makeText(getApplication(), "Downloaded to " + pair, Toast.LENGTH_SHORT).show();
+//
+//                                    ImageView imageView = new ImageView(SampleAct.this);
+//                                    imageView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+//                                            ViewGroup.LayoutParams.WRAP_CONTENT));
+//                                    ((ViewGroup) findViewById(R.id.container)).addView(imageView);
+//
+//                                    Glide.with(SampleAct.this)
+//                                            .load(R.mipmap.ic_launcher)
+//                                            .into(imageView);
+                                }
                             }
 
                             @Override
                             public void onError(Throwable e) {
+                                Log.d(TAG, "onError() called with: e = [" + e + "]");
                                 Toast.makeText(getApplication(), "Error!", Toast.LENGTH_SHORT).show();
                             }
 
                             @Override
                             public void onComplete() {
+                                Log.d(TAG, "onComplete() called");
                                 Log.d("Sample", "Is in main thread? " + (Looper.getMainLooper() == Looper.myLooper()));
                             }
                         });

--- a/app/src/main/java/com/esafirm/rxdownloadmanager/SampleActivity.java
+++ b/app/src/main/java/com/esafirm/rxdownloadmanager/SampleActivity.java
@@ -1,0 +1,96 @@
+package com.esafirm.rxdownloadmanager;
+
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.PermissionChecker;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.Toast;
+
+import com.bumptech.glide.Glide;
+import com.esafirm.rxdownloader.RxDownloader;
+
+import io.reactivex.SingleObserver;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Created by esa on 11/11/15, with awesomeness
+ */
+public class SampleActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.download_simple);
+        checkPermission();
+    }
+
+    private void startSample() {
+        findViewById(R.id.btn_download).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                RxDownloader rxDownloader = new RxDownloader(SampleActivity.this);
+                rxDownloader.download(
+                        "https://upload.wikimedia.org/wikipedia/en/e/ed/Nyan_cat_250px_frame.PNG",
+                        "nyancat photo",
+                        "image/jpg",
+                        true)
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(new SingleObserver<String>() {
+                            @Override
+                            public void onSubscribe(Disposable d) {
+                                // do nothing
+                            }
+
+                            @Override
+                            public void onSuccess(String filePath) {
+                                Toast.makeText(getApplication(), "Downloaded to " + filePath, Toast.LENGTH_SHORT).show();
+
+                                ImageView imageView = new ImageView(SampleActivity.this);
+                                imageView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                                        ViewGroup.LayoutParams.WRAP_CONTENT));
+                                ((ViewGroup) findViewById(R.id.container)).addView(imageView);
+
+                                Glide.with(SampleActivity.this)
+                                        .load(filePath)
+                                        .into(imageView);
+                            }
+
+                            @Override
+                            public void onError(Throwable e) {
+                                Toast.makeText(getApplication(), "Error!", Toast.LENGTH_SHORT).show();
+                            }
+                        });
+            }
+        });
+    }
+
+    private void checkPermission() {
+        final String permission = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+        int permissionCheck = ContextCompat.checkSelfPermission(this, permission);
+
+        if (permissionCheck != PermissionChecker.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this, new String[]{permission}, 0);
+            return;
+        }
+        startSample();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode != 0) return;
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            startSample();
+        }
+    }
+}

--- a/app/src/main/java/com/esafirm/rxdownloadmanager/SampleProgressActivity.java
+++ b/app/src/main/java/com/esafirm/rxdownloadmanager/SampleProgressActivity.java
@@ -5,9 +5,9 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.PermissionChecker;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -25,14 +25,14 @@ import io.reactivex.schedulers.Schedulers;
 /**
  * Created by esa on 11/11/15, with awesomeness
  */
-public class SampleAct extends FragmentActivity {
+public class SampleProgressActivity extends AppCompatActivity {
 
     private TextView tv_progress;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.main);
+        setContentView(R.layout.download_progress);
         checkPermission();
     }
 
@@ -41,7 +41,7 @@ public class SampleAct extends FragmentActivity {
         findViewById(R.id.btn_download).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                RxDownloader rxDownloader = new RxDownloader(SampleAct.this);
+                RxDownloader rxDownloader = new RxDownloader(SampleProgressActivity.this);
                 rxDownloader.downloadWithProgress(
                         "http://ipv4.download.thinkbroadband.com/20MB.zip",
                         "20MB.zip",
@@ -72,6 +72,7 @@ public class SampleAct extends FragmentActivity {
                             @Override
                             public void onComplete() {
                                 // do nothing
+                                tv_progress.setText("Download finished");
                             }
                         });
             }

--- a/app/src/main/res/layout/download_progress.xml
+++ b/app/src/main/res/layout/download_progress.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="?android:actionBarSize"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:id="@+id/container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+    </ScrollView>
+
+    <Button
+        android:id="@+id/btn_download"
+        android:layout_width="match_parent"
+        android:layout_height="?android:actionBarSize"
+        android:layout_gravity="bottom"
+        android:gravity="center"
+        android:text="Download" />
+
+    <TextView
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:textAppearance="?android:textAppearanceLarge"
+        android:textSize="48sp"
+        tools:text="100%" />
+</FrameLayout>

--- a/app/src/main/res/layout/download_simple.xml
+++ b/app/src/main/res/layout/download_simple.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="?android:actionBarSize"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:id="@+id/container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+    </ScrollView>
+
+    <Button
+        android:id="@+id/btn_download"
+        android:layout_width="match_parent"
+        android:layout_height="?android:actionBarSize"
+        android:layout_gravity="bottom"
+        android:gravity="center"
+        android:text="Download" />
+</FrameLayout>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools">
+    android:layout_height="match_parent">
 
-    <ScrollView android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginBottom="?actionBarSize"
-                android:fillViewport="true">
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="?android:actionBarSize"
+        android:fillViewport="true">
 
         <LinearLayout
             android:id="@+id/container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"/>
+            android:orientation="vertical" />
 
     </ScrollView>
 
     <Button
         android:id="@+id/btn_download"
         android:layout_width="match_parent"
-        android:layout_height="?actionBarSize"
+        android:layout_height="?android:actionBarSize"
         android:layout_gravity="bottom"
         android:gravity="center"
-        android:text="Download"/>
+        android:text="Download" />
+
     <TextView
         android:id="@+id/progress"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="center"
         android:textAppearance="?android:textAppearanceLarge"
-        android:layout_gravity="right|top"
-        tools:text="100"/>
+        android:textSize="48sp"
+        tools:text="100%" />
 </FrameLayout>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginBottom="?android:actionBarSize"
-        android:fillViewport="true">
-
-        <LinearLayout
-            android:id="@+id/container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical" />
-
-    </ScrollView>
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
 
     <Button
-        android:id="@+id/btn_download"
-        android:layout_width="match_parent"
-        android:layout_height="?android:actionBarSize"
-        android:layout_gravity="bottom"
-        android:gravity="center"
-        android:text="Download" />
-
-    <TextView
-        android:id="@+id/progress"
-        android:layout_width="wrap_content"
+        android:id="@+id/button_simple"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:textAppearance="?android:textAppearanceLarge"
-        android:textSize="48sp"
-        tools:text="100%" />
-</FrameLayout>
+        android:layout_marginEnd="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="Simple Download"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/button_progress"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="Download with Progress"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/button_simple" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <ScrollView android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -24,5 +24,11 @@
         android:layout_gravity="bottom"
         android:gravity="center"
         android:text="Download"/>
-
+    <TextView
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:textAppearanceLarge"
+        android:layout_gravity="right|top"
+        tools:text="100"/>
 </FrameLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0-beta2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0-beta3'
+        classpath 'com.android.tools.build:gradle:3.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.1.0-beta3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 27 10:47:43 MSK 2017
+#Thu Feb 15 12:12:38 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '26.0.2'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 14

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,4 +22,5 @@ dependencies {
 
     /* Rx */
     implementation 'io.reactivex.rxjava2:rxjava:2.1.6'
+    testImplementation 'junit:junit:4.12'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,8 +18,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     /* Rx */
-    compile 'io.reactivex.rxjava2:rxjava:2.1.6'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.6'
 }

--- a/library/src/main/java/com/esafirm/rxdownloader/DownloadState.java
+++ b/library/src/main/java/com/esafirm/rxdownloader/DownloadState.java
@@ -1,0 +1,22 @@
+package com.esafirm.rxdownloader;
+
+/**
+ * Represents download state
+ */
+public final class DownloadState {
+    public final int progress;
+    public final String path;
+
+    /**
+     * @param progress progress as a percentage (0-100)
+     * @param path path of the downloaded file. May be null if not completed.
+     */
+    public DownloadState(int progress, String path) {
+        this.progress = progress;
+        this.path = path;
+    }
+
+    /*package*/ static DownloadState create(int progress, String path) {
+        return new DownloadState(progress, path);
+    }
+}

--- a/library/src/main/java/com/esafirm/rxdownloader/DownloadState.java
+++ b/library/src/main/java/com/esafirm/rxdownloader/DownloadState.java
@@ -3,7 +3,7 @@ package com.esafirm.rxdownloader;
 /**
  * Represents download state
  */
-public final class DownloadState {
+public class DownloadState {
     public final int progress;
     public final String path;
 

--- a/library/src/main/java/com/esafirm/rxdownloader/DownloadState.java
+++ b/library/src/main/java/com/esafirm/rxdownloader/DownloadState.java
@@ -11,12 +11,9 @@ public final class DownloadState {
      * @param progress progress as a percentage (0-100)
      * @param path path of the downloaded file. May be null if not completed.
      */
-    public DownloadState(int progress, String path) {
+    /*package*/ DownloadState(int progress, String path) {
         this.progress = progress;
         this.path = path;
     }
 
-    /*package*/ static DownloadState create(int progress, String path) {
-        return new DownloadState(progress, path);
-    }
 }

--- a/library/src/main/java/com/esafirm/rxdownloader/DownloadState.java
+++ b/library/src/main/java/com/esafirm/rxdownloader/DownloadState.java
@@ -16,4 +16,7 @@ public class DownloadState {
         this.path = path;
     }
 
+    public boolean isComplete() {
+        return path != null && path.length() > 0;
+    }
 }

--- a/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
+++ b/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
@@ -13,8 +13,6 @@ import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.ObservableSource;
 import io.reactivex.Single;
 import io.reactivex.annotations.NonNull;
@@ -84,12 +82,7 @@ public class RxDownloader {
     }
 
     public Single<String> download(DownloadManager.Request request) {
-        long downloadId = getDownloadManager().enqueue(request);
-
-        PublishSubject<DownloadState> publishSubject = PublishSubject.create();
-        progressSubjectMap.put(downloadId, publishSubject);
-
-        return publishSubject
+        return downloadWithProgress(request)
                 .filter(new Predicate<DownloadState>() {
                     @Override
                     public boolean test(DownloadState s) {

--- a/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
+++ b/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
@@ -52,33 +52,33 @@ public class RxDownloader {
     }
 
     public Single<String> download(@NonNull String url,
-                                             @NonNull String filename,
-                                             boolean showCompletedNotification) {
+                                   @NonNull String filename,
+                                   boolean showCompletedNotification) {
         return download(url, filename, DEFAULT_MIME_TYPE, showCompletedNotification);
     }
 
     public Single<String> download(@NonNull String url,
-                                             @NonNull String filename,
-                                             @NonNull String mimeType,
-                                             boolean showCompletedNotification) {
+                                   @NonNull String filename,
+                                   @NonNull String mimeType,
+                                   boolean showCompletedNotification) {
         return download(createRequest(url, filename, null,
                 mimeType, true, showCompletedNotification));
     }
 
     public Single<String> download(@NonNull String url,
-                                             @NonNull String filename,
-                                             @NonNull String destinationPath,
-                                             @NonNull String mimeType,
-                                             boolean showCompletedNotification) {
+                                   @NonNull String filename,
+                                   @NonNull String destinationPath,
+                                   @NonNull String mimeType,
+                                   boolean showCompletedNotification) {
         return download(createRequest(url, filename, destinationPath,
                 mimeType, true, showCompletedNotification));
     }
 
     public Single<String> downloadInFilesDir(@NonNull String url,
-                                                       @NonNull String filename,
-                                                       @NonNull String destinationPath,
-                                                       @NonNull String mimeType,
-                                                       boolean showCompletedNotification) {
+                                             @NonNull String filename,
+                                             @NonNull String destinationPath,
+                                             @NonNull String mimeType,
+                                             boolean showCompletedNotification) {
         return download(createRequest(url, filename, destinationPath,
                 mimeType, false, showCompletedNotification));
     }

--- a/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
+++ b/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
@@ -8,14 +8,28 @@ import android.content.IntentFilter;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
+import android.util.Log;
+import android.util.Pair;
 
 import com.esafirm.rxdownloader.utils.LongSparseArray;
 
-import java.io.File;
+import org.reactivestreams.Publisher;
 
+import java.io.File;
+import java.util.concurrent.Callable;
+
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableEmitter;
+import io.reactivex.FlowableOnSubscribe;
 import io.reactivex.Observable;
+import io.reactivex.Scheduler;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.annotations.Nullable;
+import io.reactivex.flowables.ConnectableFlowable;
+import io.reactivex.functions.Function;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 /**
@@ -24,16 +38,18 @@ import io.reactivex.subjects.PublishSubject;
 public class RxDownloader {
 
     private static final String DEFAULT_MIME_TYPE = "*/*";
+    private static final String TAG = RxDownloader.class.getSimpleName();
 
     private Context context;
-    private LongSparseArray<PublishSubject<String>> subjectMap = new LongSparseArray<>();
+    //    private LongSparseArray<PublishSubject<String>> subjectMap = new LongSparseArray<>();
+    private LongSparseArray<PublishProcessor<Pair<Integer, String>>> progressSubjectMap = new LongSparseArray<>();
     private DownloadManager downloadManager;
 
     public RxDownloader(@NonNull Context context) {
         this.context = context.getApplicationContext();
-        DownloadStatusReceiver downloadStatusReceiver = new DownloadStatusReceiver();
-        IntentFilter intentFilter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
-        context.registerReceiver(downloadStatusReceiver, intentFilter);
+//        DownloadStatusReceiver downloadStatusReceiver = new DownloadStatusReceiver();
+//        IntentFilter intentFilter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
+//        context.registerReceiver(downloadStatusReceiver, intentFilter);
     }
 
     @NonNull
@@ -47,45 +63,112 @@ public class RxDownloader {
         return downloadManager;
     }
 
-    public Observable<String> download(@NonNull String url,
-                                       @NonNull String filename,
-                                       boolean showCompletedNotification) {
+    public Flowable<String> download(@NonNull String url,
+                                     @NonNull String filename,
+                                     boolean showCompletedNotification) {
         return download(url, filename, DEFAULT_MIME_TYPE, showCompletedNotification);
     }
 
-    public Observable<String> download(@NonNull String url,
-                                       @NonNull String filename,
-                                       @NonNull String mimeType,
-                                       boolean showCompletedNotification) {
+    public Flowable<String> download(@NonNull String url,
+                                     @NonNull String filename,
+                                     @NonNull String mimeType,
+                                     boolean showCompletedNotification) {
         return download(createRequest(url, filename, null,
                 mimeType, true, showCompletedNotification));
     }
 
-    public Observable<String> download(@NonNull String url,
-                                       @NonNull String filename,
-                                       @NonNull String destinationPath,
-                                       @NonNull String mimeType,
-                                       boolean showCompletedNotification) {
+    public Flowable<String> download(@NonNull String url,
+                                     @NonNull String filename,
+                                     @NonNull String destinationPath,
+                                     @NonNull String mimeType,
+                                     boolean showCompletedNotification) {
         return download(createRequest(url, filename, destinationPath,
                 mimeType, true, showCompletedNotification));
     }
 
-    public Observable<String> downloadInFilesDir(@NonNull String url,
-                                                 @NonNull String filename,
-                                                 @NonNull String destinationPath,
-                                                 @NonNull String mimeType,
-                                                 boolean showCompletedNotification) {
+    public Flowable<String> downloadInFilesDir(@NonNull String url,
+                                               @NonNull String filename,
+                                               @NonNull String destinationPath,
+                                               @NonNull String mimeType,
+                                               boolean showCompletedNotification) {
         return download(createRequest(url, filename, destinationPath,
                 mimeType, false, showCompletedNotification));
     }
 
-    public Observable<String> download(DownloadManager.Request request) {
+    public Flowable<String> download(DownloadManager.Request request) {
         long downloadId = getDownloadManager().enqueue(request);
 
-        PublishSubject<String> publishSubject = PublishSubject.create();
-        subjectMap.put(downloadId, publishSubject);
+        PublishProcessor<Pair<Integer, String>> publishProcessor = PublishProcessor.create();
+        progressSubjectMap.put(downloadId, publishProcessor);
 
-        return publishSubject;
+        return publishProcessor.flatMap(new Function<Pair<Integer, String>, Publisher<String>>() {
+            @Override
+            public Publisher<String> apply(Pair<Integer, String> pair) {
+                return Flowable.just(pair.second);
+            }
+        });
+    }
+
+    public Flowable<Pair<Integer, String>> downloadWithProgress(DownloadManager.Request request) {
+        final long downloadId = getDownloadManager().enqueue(request);
+
+        final PublishProcessor<Pair<Integer, String>> publishProcessor = PublishProcessor.create();
+        progressSubjectMap.put(downloadId, publishProcessor);
+
+//                        ;
+        Flowable<Pair<Integer, String>> flowable =
+                Flowable.defer(new Callable<Publisher<Pair<Integer, String>>>() {
+                    @Override
+                    public Publisher<Pair<Integer, String>> call() {
+                        return
+                                Flowable.create(new FlowableOnSubscribe<Pair<Integer, String>>() {
+                                    @Override
+                                    public void subscribe(FlowableEmitter<Pair<Integer, String>> e) throws Exception {
+                                        Log.d(TAG, "subscribe: listening for progress");
+                                        DownloadManager.Query query = new DownloadManager.Query();
+                                        query.setFilterById(downloadId);
+                                        while (true) {
+                                            Cursor cursor = getDownloadManager().query(query);
+                                            cursor.moveToFirst();
+                                            int bytesDownloaded = cursor.getInt(cursor
+                                                    .getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));
+                                            int bytesTotal = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES));
+
+                                            int status = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS));
+                                            int uriIndex = cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI);
+                                            String downloadedPackageUriString = cursor.getString(uriIndex);
+                                            cursor.close();
+                                            if (status == DownloadManager.STATUS_SUCCESSFUL) {
+                                                e.onNext(Pair.create(100, downloadedPackageUriString));
+                                                e.onComplete();
+                                                break;
+                                            } else if (status == DownloadManager.STATUS_FAILED) {
+                                                e.onError(new RuntimeException("Download not complete"));
+                                                break;
+                                            }
+//                                    cursor.close();
+                                            final int progress = (int) ((bytesDownloaded * 1f) / bytesTotal * 100);
+                                            Log.d(TAG, "progress: " + progress + ", status: " + status);
+                                            Log.d(TAG, "downloaded: " + bytesDownloaded + "B, total: " + bytesTotal + "B status: " + status);
+                                            e.onNext(Pair.<Integer, String>create(progress, null));
+                                            Thread.sleep(500);
+                                        }
+                                    }
+                                }, BackpressureStrategy.LATEST)
+                                        /*.publish()
+                                        .autoConnect()*/;
+                    }
+                });
+//        flowable.subscribe();
+
+//                .subscribeOn(Schedulers.io())
+//                .publish()
+//                .autoConnect();
+
+        flowable/*.publish()
+                .autoConnect()*/
+                .subscribe(publishProcessor);
+        return publishProcessor;
     }
 
     private DownloadManager.Request createRequest(@NonNull String url,
@@ -136,45 +219,53 @@ public class RxDownloader {
         }
     }
 
-    private class DownloadStatusReceiver extends BroadcastReceiver {
-
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            long id = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0L);
-            PublishSubject<String> publishSubject = subjectMap.get(id);
-
-            if (publishSubject == null)
-                return;
-
-            DownloadManager.Query query = new DownloadManager.Query();
-            query.setFilterById(id);
-            DownloadManager downloadManager = getDownloadManager();
-            Cursor cursor = downloadManager.query(query);
-
-            if (!cursor.moveToFirst()) {
-                cursor.close();
-                downloadManager.remove(id);
-                publishSubject.onError(new IllegalStateException("Cursor empty, this shouldn't happened"));
-                subjectMap.remove(id);
-                return;
-            }
-
-            int statusIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS);
-            if (DownloadManager.STATUS_SUCCESSFUL != cursor.getInt(statusIndex)) {
-                cursor.close();
-                downloadManager.remove(id);
-                publishSubject.onError(new IllegalStateException("Download Failed"));
-                subjectMap.remove(id);
-                return;
-            }
-
-            int uriIndex = cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI);
-            String downloadedPackageUriString = cursor.getString(uriIndex);
-            cursor.close();
-
-            publishSubject.onNext(downloadedPackageUriString);
-            publishSubject.onComplete();
-            subjectMap.remove(id);
-        }
+    public Flowable<Pair<Integer, String>> downloadWithProgress(@NonNull String url,
+                                                                @NonNull String filename,
+                                                                @NonNull String mimeType,
+                                                                boolean showCompletedNotification) {
+        return downloadWithProgress(createRequest(url, filename, null,
+                mimeType, true, showCompletedNotification));
     }
+
+//    private class DownloadStatusReceiver extends BroadcastReceiver {
+//
+//        @Override
+//        public void onReceive(Context context, Intent intent) {
+//            long id = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0L);
+//            PublishProcessor<Pair<Integer, String>> publishSubject = progressSubjectMap.get(id);
+//
+//            if (publishSubject == null)
+//                return;
+//
+//            DownloadManager.Query query = new DownloadManager.Query();
+//            query.setFilterById(id);
+//            DownloadManager downloadManager = getDownloadManager();
+//            Cursor cursor = downloadManager.query(query);
+//
+//            if (!cursor.moveToFirst()) {
+//                cursor.close();
+//                downloadManager.remove(id);
+//                publishSubject.onError(new IllegalStateException("Cursor empty, this shouldn't happened"));
+//                progressSubjectMap.remove(id);
+//                return;
+//            }
+//
+//            int statusIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS);
+//            if (DownloadManager.STATUS_SUCCESSFUL != cursor.getInt(statusIndex)) {
+//                cursor.close();
+//                downloadManager.remove(id);
+//                publishSubject.onError(new IllegalStateException("Download Failed"));
+//                progressSubjectMap.remove(id);
+//                return;
+//            }
+//
+//            int uriIndex = cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI);
+//            String downloadedPackageUriString = cursor.getString(uriIndex);
+//            cursor.close();
+//
+//            publishSubject.onNext(downloadedPackageUriString);
+//            publishSubject.onComplete();
+//            subjectMap.remove(id);
+//        }
+//    }
 }

--- a/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
+++ b/library/src/main/java/com/esafirm/rxdownloader/RxDownloader.java
@@ -135,13 +135,13 @@ public class RxDownloader {
                                 cursor.close();
                                 if (status == DownloadManager.STATUS_SUCCESSFUL) {
                                     progressSubjectMap.remove(downloadId);
-                                    return Observable.just(DownloadState.create(100, downloadedPackageUriString));
+                                    return Observable.just(new DownloadState(100, downloadedPackageUriString));
                                 } else if (status == DownloadManager.STATUS_FAILED) {
                                     progressSubjectMap.remove(downloadId);
                                     return Observable.error(new RuntimeException("Download not complete"));
                                 }
                                 final int progress = (int) ((bytesDownloaded * 1f) / bytesTotal * 100);
-                                return Observable.just(DownloadState.create(progress, null));
+                                return Observable.just(new DownloadState(progress, null));
                             }
                         })
                         .takeUntil(new Predicate<DownloadState>() {

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">RxDownloader</string>
-</resources>

--- a/library/src/test/java/com/esafirm/rxdownloader/DownloadStateTest.java
+++ b/library/src/test/java/com/esafirm/rxdownloader/DownloadStateTest.java
@@ -1,0 +1,25 @@
+package com.esafirm.rxdownloader;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DownloadStateTest {
+    @Test
+    public void noPathGiven_downloadIncomplete() {
+        DownloadState state = new DownloadState(0, null);
+        assertFalse(state.isComplete());
+    }
+
+    @Test
+    public void emptyPathGiven_downloadIncomplete() {
+        DownloadState state = new DownloadState(0, "");
+        assertFalse(state.isComplete());
+    }
+
+    @Test
+    public void withPath_downloadIncomplete() {
+        DownloadState state = new DownloadState(0, "/media/sdcard/example.jpg");
+        assertTrue(state.isComplete());
+    }
+}


### PR DESCRIPTION
Have managed a Proof of Concept to make a progress observable to address #7. It's not quite ready, but I think I'll move the conversation to here instead on the issue.

I've just remembered I was supposed to make a `DownloadProgressState` object instead of a `Pair`, so will change that.

Another thing I mentioned on the issue was what to do with the sample. I could partition the screen in to two to show example of both image download with no progress and a large download with progress. At the moment, I've replaced the image download with the progress download.

Also, I don't expect this to be pulled in as is, because it is messy so will squish together or do what you'd like. It also contains changes to work with Android Studio 3.1 Beta 3. Would you rather I split up this pull request as a series of them or are you happy with it as it is?

Can you take a look, @esafirm?